### PR TITLE
Add close and exit method for cursor

### DIFF
--- a/wherobots/db/constants.py
+++ b/wherobots/db/constants.py
@@ -1,5 +1,5 @@
 from enum import auto
-from strenum import StrEnum
+from strenum import LowercaseStrEnum
 
 from .region import Region
 from .runtime import Runtime
@@ -14,7 +14,7 @@ DEFAULT_SESSION_WAIT_TIMEOUT_SECONDS: float = 300
 MAX_MESSAGE_SIZE: int = 100 * 2**20  # 100MiB
 
 
-class ExecutionState(StrEnum):
+class ExecutionState(LowercaseStrEnum):
     IDLE = auto()
     "Not executing any operation."
 
@@ -40,21 +40,21 @@ class ExecutionState(StrEnum):
         return self in (ExecutionState.COMPLETED, ExecutionState.FAILED)
 
 
-class RequestKind(StrEnum):
+class RequestKind(LowercaseStrEnum):
     EXECUTE_SQL = auto()
     RETRIEVE_RESULTS = auto()
 
 
-class EventKind(StrEnum):
+class EventKind(LowercaseStrEnum):
     STATE_UPDATED = auto()
     EXECUTION_RESULT = auto()
     ERROR = auto()
 
 
-class ResultsFormat(StrEnum):
+class ResultsFormat(LowercaseStrEnum):
     JSON = auto()
     ARROW = auto()
 
 
-class DataCompression(StrEnum):
+class DataCompression(LowercaseStrEnum):
     BROTLI = auto()

--- a/wherobots/db/cursor.py
+++ b/wherobots/db/cursor.py
@@ -77,8 +77,18 @@ class Cursor:
     def fetchall(self):
         return self.__get_results()[self.__current_row :]
 
+    def close(self):
+        """Close the cursor."""
+        pass
+
     def __iter__(self):
         return self
 
     def __next__(self):
         raise StopIteration
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()


### PR DESCRIPTION
`cursor.close()` is defined by PEP249 as an optional operation. We don't need it now to make the driver function as we always auto-commit and has no transaction.

Airflow's SQL operator has code for executing SQL defined already which use `with closing(conn.cursor()) as cur` that expect the cursor to have `close()` method no matter what. Having it can get the airflow provider rid of extra codings.

When people coding  a general SQL client that support various DbAPI drivers they will also use expressions like `with conn.cursor()` for sure.

So adding an empty close() and the according context support can help us adapt to more clients.