### PR TITLE
feat: pass through advanced parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ $ pip install git+https://github.com/wherobots/wherobots-python-dbapi-driver
 
 ## Usage
 
+### Basic usage
+
+Basic usage follows the typical pattern of establishing the connection,
+acquiring a cursor, and executing SQL queries through it:
+
 ```python
 from wherobots.db import connect
 from wherobots.db.region import Region
@@ -36,8 +41,8 @@ with connect(
     print(results)
 ```
 
-The `Cursor` also supports the context manager protocol, so you can use
-it within a `with` statement when needed:
+The `Cursor` supports the context manager protocol, so you can use it
+within a `with` statement when needed:
 
 ```python
 with connect(...) as conn:
@@ -49,3 +54,30 @@ with connect(...) as conn:
 It also implements the `close()` method, as suggested by the PEP-2049
 specification, to support situations where the cursor is wrapped in a
 `contextmanager.closing()`.
+
+### Runtime and region selection
+
+You can chose the Wherobots runtime you want to use using the `runtime`
+parameter, passing in one of the `Runtime` enum values. For more
+information on runtime sizing and selection, please consult the
+[Wherobots product documentation](https://docs.wherobots.com).
+
+The only supported Wherobots compute region for now is `aws-us-west-2`,
+in AWS's Oregon (`us-west-2`) region.
+
+### Advanced parameters
+
+The `connect()` method takes some additional parameters that advanced
+users may find useful:
+
+* `results_format`: one of the `ResultsFormat` enum values;
+    Arrow encoding is the default and most efficient format for
+    receiving query results.
+* `data_compression`: one of the `DataCompression` enum values; Brotli
+    compression is the default and the most efficient compression
+    algorithm for receiving query results.
+* `geometry_representation`: one of the `GeometryRepresentation` enum
+    values; selects the encoding of geometry columns returned to the
+    client application. The default is EWKT (string) and the most
+    convenient for human inspection while still being usable by
+    libraries like Shapely.

--- a/wherobots/db/constants.py
+++ b/wherobots/db/constants.py
@@ -58,3 +58,11 @@ class ResultsFormat(LowercaseStrEnum):
 
 class DataCompression(LowercaseStrEnum):
     BROTLI = auto()
+
+
+class GeometryRepresentation(LowercaseStrEnum):
+    WKT = auto()
+    WKB = auto()
+    EWKT = auto()
+    EWKB = auto()
+    GEOJSON = auto()

--- a/wherobots/db/driver.py
+++ b/wherobots/db/driver.py
@@ -18,6 +18,9 @@ from .constants import (
     DEFAULT_READ_TIMEOUT_SECONDS,
     DEFAULT_SESSION_WAIT_TIMEOUT_SECONDS,
     MAX_MESSAGE_SIZE,
+    ResultsFormat,
+    DataCompression,
+    GeometryRepresentation,
 )
 from .errors import (
     InterfaceError,
@@ -40,6 +43,9 @@ def connect(
     region: Region = None,
     wait_timeout: float = DEFAULT_SESSION_WAIT_TIMEOUT_SECONDS,
     read_timeout: float = DEFAULT_READ_TIMEOUT_SECONDS,
+    results_format: ResultsFormat | None = None,
+    data_compression: DataCompression | None = None,
+    geometry_representation: GeometryRepresentation | None = None,
 ) -> Connection:
     if not token and not api_key:
         raise ValueError("At least one of `token` or `api_key` is required")
@@ -113,6 +119,9 @@ def connect(
         uri=http_to_ws(session_uri),
         headers=headers,
         read_timeout=read_timeout,
+        results_format=results_format,
+        data_compression=data_compression,
+        geometry_representation=geometry_representation,
     )
 
 
@@ -129,6 +138,9 @@ def connect_direct(
     uri: str,
     headers: dict[str, str] = None,
     read_timeout: float = DEFAULT_READ_TIMEOUT_SECONDS,
+    results_format: ResultsFormat | None = None,
+    data_compression: DataCompression | None = None,
+    geometry_representation: GeometryRepresentation | None = None,
 ) -> Connection:
     q = queue.SimpleQueue()
 
@@ -156,4 +168,10 @@ def connect_direct(
     if isinstance(result, Exception):
         raise InterfaceError("Failed to connect to SQL session!") from result
 
-    return Connection(result, read_timeout)
+    return Connection(
+        result,
+        read_timeout=read_timeout,
+        results_format=results_format,
+        data_compression=data_compression,
+        geometry_representation=geometry_representation,
+    )


### PR DESCRIPTION
Take in `results_format`, `data_compression`, and
`geometry_representation` - with sensible defaults - instead of relying on hardcoded values.